### PR TITLE
Normalize settings model and popup UI (preserve hoverDelay, explicit trigger key)

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,7 +12,8 @@ let triggerKey = '';
 let listenersAttached = false;
 
 function normalizeInteractionType(value) {
-  return value === 'button' ? 'hoverWithKey' : value;
+  if (value === 'button') return 'hoverWithKey';
+  return value === 'hoverWithKey' ? 'hoverWithKey' : 'hover';
 }
 
 function normalizeTriggerKey(settings) {

--- a/popup.html
+++ b/popup.html
@@ -131,7 +131,7 @@
         <label><input type="radio" name="interaction-type" value="hoverWithKey" id="interaction-hover-with-key"> Hover + key</label>
         <div class="key-selector" id="key-selector">
           <button id="set-key-btn">Set key</button>
-          <span id="key-display">None</span>
+          <span id="key-display">No key selected</span>
         </div>
       </div>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const delayContainer = document.getElementById('delay-container');
 
   function normalizeInteractionType(value) {
-    return value === 'button' ? 'hoverWithKey' : value;
+    if (value === 'button') return 'hoverWithKey';
+    return value === 'hoverWithKey' ? 'hoverWithKey' : 'hover';
   }
 
   function normalizeTriggerKey(settings) {
@@ -42,8 +43,24 @@ document.addEventListener('DOMContentLoaded', () => {
     return display.toUpperCase();
   }
 
+  function getTriggerKeyDisplay(code) {
+    return code ? codeToLabel(code) : 'No key selected';
+  }
+
   function setKeyDisplay(code) {
-    keyDisplay.textContent = code ? codeToLabel(code) : 'None';
+    keyDisplay.textContent = getTriggerKeyDisplay(code);
+  }
+
+  function renderInteractionSettings(interactionType, hoverDelayValue, triggerKeyValue) {
+    const isHover = interactionType === 'hover';
+    interactionHover.checked = isHover;
+    interactionHoverWithKey.checked = !isHover;
+    delaySlider.disabled = !isHover;
+    keySelector.style.display = isHover ? 'none' : 'flex';
+    delayContainer.style.display = isHover ? 'flex' : 'none';
+    delaySlider.value = hoverDelayValue;
+    delayLabel.textContent = hoverDelayValue + ' ms';
+    setKeyDisplay(triggerKeyValue);
   }
 
   // Load initial state and settings
@@ -63,24 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       toggle.checked = data.enabled;
       maxInput.value = data.maxPopups;
-      delaySlider.value = data.hoverDelay;
-      delayLabel.textContent = data.hoverDelay + ' ms';
-
-      // Initialize interaction UI and key selector visibility
-      if (interactionType === 'hover') {
-        interactionHover.checked = true;
-        delaySlider.disabled = false;
-        keySelector.style.display = 'none';
-        delayContainer.style.display = 'flex';
-      } else {
-        interactionHoverWithKey.checked = true;
-        delaySlider.value = 0;
-        delayLabel.textContent = '0 ms';
-        delaySlider.disabled = true;
-        keySelector.style.display = 'flex';
-        setKeyDisplay(triggerKey);
-        delayContainer.style.display = 'none';
-      }
+      renderInteractionSettings(interactionType, data.hoverDelay, triggerKey);
       updateIcon(data.enabled);
     }
   );
@@ -110,28 +110,20 @@ document.addEventListener('DOMContentLoaded', () => {
   interactionHover.addEventListener('change', () => {
     if (interactionHover.checked) {
       chrome.storage.local.set({ interactionType: 'hover' });
-      const defaultDelay = 1500;
-      chrome.storage.local.set({ hoverDelay: defaultDelay });
-      delaySlider.value = defaultDelay;
-      delayLabel.textContent = defaultDelay + ' ms';
-      delaySlider.disabled = false;
-      keySelector.style.display = 'none';
-      delayContainer.style.display = 'flex';
+      chrome.storage.local.get({ hoverDelay: 2000, triggerKey: '', interactionKey: '' }, (settings) => {
+        const triggerKey = normalizeTriggerKey(settings);
+        renderInteractionSettings('hover', settings.hoverDelay, triggerKey);
+      });
     }
   });
 
   interactionHoverWithKey.addEventListener('change', () => {
     if (interactionHoverWithKey.checked) {
       chrome.storage.local.set({ interactionType: 'hoverWithKey' });
-      chrome.storage.local.set({ hoverDelay: 0 });
-      delaySlider.value = 0;
-      delayLabel.textContent = '0 ms';
-      delaySlider.disabled = true;
-      keySelector.style.display = 'flex';
-      chrome.storage.local.get({ triggerKey: '', interactionKey: '' }, (settings) => {
-        setKeyDisplay(normalizeTriggerKey(settings));
+      chrome.storage.local.get({ hoverDelay: 2000, triggerKey: '', interactionKey: '' }, (settings) => {
+        const triggerKey = normalizeTriggerKey(settings);
+        renderInteractionSettings('hoverWithKey', settings.hoverDelay, triggerKey);
       });
-      delayContainer.style.display = 'none';
     }
   });
 


### PR DESCRIPTION
### Motivation
- Make the popup settings UI and storage model honest and consistent with the required settings model (`enabled`, `maxPopups`, `interactionType`, `hoverDelay`, `triggerKey`) without changing runtime popup architecture. 
- Ensure `hoverDelay` is always persisted and not mutated as a side effect of switching modes, and ensure the trigger key UI is never blank.

### Description
- Updated `popup.js` to centralize UI rendering via `renderInteractionSettings()` and to stop writing `hoverDelay: 0` or resetting delay when switching modes, instead reading and showing the stored `hoverDelay` as required. 
- Replaced the empty key label and display logic so the trigger key UI always shows a non-empty string and uses the exact text `No key selected` when unset via `getTriggerKeyDisplay()` and `setKeyDisplay()`. 
- Tightened normalization logic in both `popup.js` and `content.js` so `interactionType` resolves only to `hover` or `hoverWithKey` while still accepting legacy `button` on read, and preserved minimal migration that maps legacy `interactionKey` → `triggerKey`. 
- Updated `popup.html` default label for the key display to `No key selected` and hid the delay block in `hoverWithKey` while restoring the real stored `hoverDelay` when returning to `hover`.

### Testing
- Ran syntax checks `node --check popup.js` which succeeded. 
- Ran syntax checks `node --check content.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c93b130980832f8dcfe574d8590ac9)