### PR TITLE
Introduce popup entity identity and explicit state model

### DIFF
--- a/background.js
+++ b/background.js
@@ -58,6 +58,14 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     }
     if (msg.action === 'showPreview') {
       chrome.tabs.sendMessage(sender.tab.id, msg);
+      return;
+    }
+    if (msg.action === 'updatePopupUrl') {
+      chrome.tabs.sendMessage(sender.tab.id, {
+        action: 'updatePopupUrl',
+        popupId: msg.popupId || null,
+        url: msg.url
+      });
     }
   }
 }); 

--- a/content.js
+++ b/content.js
@@ -122,6 +122,9 @@ function handleRuntimeMessage(msg) {
     case 'bringToFront':
       bringToFront(msg.popupId, msg.url);
       break;
+    case 'updatePopupUrl':
+      syncPopupCurrentUrl(msg.popupId, msg.url);
+      break;
     default:
       break;
   }
@@ -436,4 +439,11 @@ function reloadPopup(popupId) {
     entry.iframe = newIframe;
     bindIframeStateHandlers(entry);
     simulateLoadingBar(entry);
+}
+
+function syncPopupCurrentUrl(popupId, currentUrl) {
+    if (!popupId || !currentUrl) return;
+    const entry = getPopupById(popupId);
+    if (!entry) return;
+    entry.currentUrl = currentUrl;
 }

--- a/iframe-handler.js
+++ b/iframe-handler.js
@@ -10,6 +10,25 @@ chrome.storage.onChanged.addListener((changes, area) => {
   }
 });
 if (window.self !== window.top) {
+  function sendPopupUrlUpdate() {
+    if (!iframeEnabled) return;
+    const popupId = window.frameElement && window.frameElement.dataset
+      ? window.frameElement.dataset.popupId
+      : null;
+    if (!popupId) return;
+    chrome.runtime.sendMessage({
+      action: 'updatePopupUrl',
+      popupId,
+      url: window.location.href
+    });
+  }
+
+  if (document.readyState === 'complete') {
+    sendPopupUrlUpdate();
+  } else {
+    window.addEventListener('load', sendPopupUrlUpdate, { once: true });
+  }
+
   // Handle wheel events within iframe: allow native smooth scrolling and prevent propagation to host
   document.addEventListener('wheel', e => {
     if (!iframeEnabled) return;


### PR DESCRIPTION
### Motivation
- Replace URL-only popup tracking with a stable runtime identity so popups remain the same entity when their iframe navigates.
- Make popup state explicit to enable future orchestration and to clarify load/blocked/error handling.
- Keep the change minimal and focused on identity/state without touching hover, cross-frame protocols, or background redesign.

### Description
- Converted popup records in `content.js` into explicit popup entities stored in the single `popups` collection, each with `popupId`, `requestedUrl`, `currentUrl`, `state`, DOM refs, and position metadata.
- Added a monotonic `popupIdCounter` to generate stable IDs like `popup-1`, set `state` to `loading` at creation, and update `state` to `ready`/`blocked`/`error` in iframe handlers via `bindIframeStateHandlers`.
- Switched operations to identity-based APIs: `bringToFront(popupId, urlFallback)`, `reloadPopup(popupId)`, and `closePopup(popupId)`, and wired UI buttons and event handlers to use the popup entity instead of URL lookups.
- Kept compatibility with existing URL-originated messages by adding `popupId` relay in `background.js` and sending `popupId` from `iframe-handler.js` (via `window.frameElement.dataset.popupId`) while still accepting a URL fallback.
- Preserved existing loading UI behavior (progress bar, red error state) and duplicate-prevention semantics by checking both `requestedUrl` and `currentUrl` when creating popups.

### Testing
- Ran JavaScript syntax checks with `node --check content.js && node --check iframe-handler.js && node --check background.js`, which completed successfully.
- Verified that popup lifecycle wiring is present: popups are created with `popupId` and `state` set to `loading`, `iframe.onload` updates `currentUrl` and transitions to `ready` or `blocked` (heuristic for `about:blank`), and `iframe.onerror` sets `error`.
- No behavioral changes to hover logic or background message routing were introduced beyond the minimal compatibility bridge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9400c1768832f8fc0691dd4141d55)