### PR TITLE
Enforce top-level ownership for preview-open flow

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,7 +44,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     if (msg.action === 'openKeyPreview') {
       const data = lastHovers[sender.tab.id];
       if (data && data.url) {
-        chrome.tabs.sendMessage(sender.tab.id, { action: 'showPreview', url: data.url, x: data.x, y: data.y });
+        chrome.tabs.sendMessage(sender.tab.id, { action: 'requestPreviewOpen', url: data.url, x: data.x, y: data.y, trigger: 'key' });
       }
       return;
     }
@@ -56,8 +56,14 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
       });
       return;
     }
-    if (msg.action === 'showPreview') {
-      chrome.tabs.sendMessage(sender.tab.id, msg);
+    if (msg.action === 'requestPreviewOpen' || msg.action === 'showPreview') {
+      chrome.tabs.sendMessage(sender.tab.id, {
+        action: 'requestPreviewOpen',
+        url: msg.url,
+        x: msg.x,
+        y: msg.y,
+        trigger: msg.trigger || null
+      });
       return;
     }
     if (msg.action === 'updatePopupUrl') {

--- a/content.js
+++ b/content.js
@@ -84,16 +84,23 @@ function onContentMouseMove(e) {
         hoverTimer = null;
         return;
       }
-      if (window.self === window.top) {
-        createPopup(link.href, x, y);
-      } else {
-        chrome.runtime.sendMessage({ action: 'showPreview', url: link.href, x, y });
-      }
+      requestPreviewOpen(link.href, x, y, 'hover');
       lastPreviewedLink = link.href;
       lastPreviewedTime = Date.now();
       hoverTimer = null;
     }, hoverDelay);
   }
+}
+
+function requestPreviewOpen(url, x, y, trigger) {
+  if (!enabled || !url) return;
+  chrome.runtime.sendMessage({
+    action: 'requestPreviewOpen',
+    url,
+    x,
+    y,
+    trigger: trigger || null
+  });
 }
 
 function onContentKeyDown(e) {
@@ -116,8 +123,12 @@ function handleRuntimeMessage(msg) {
   if (!enabled || window.self !== window.top) return;
 
   switch (msg.action) {
+    case 'requestPreviewOpen':
+      handlePreviewOpenRequest(msg);
+      break;
     case 'showPreview':
-      createPopup(msg.url, msg.x, msg.y);
+      // Legacy relay path: normalize to the single preview-open handler.
+      handlePreviewOpenRequest(msg);
       break;
     case 'bringToFront':
       bringToFront(msg.popupId, msg.url);
@@ -178,6 +189,13 @@ chrome.storage.onChanged.addListener((changes, area) => {
 
 // z-index counter to manage popup stacking
 let zIndexCounter = 1000;
+
+function handlePreviewOpenRequest(msg) {
+  if (!msg || !msg.url) return;
+  const x = typeof msg.x === 'number' ? msg.x : 0;
+  const y = typeof msg.y === 'number' ? msg.y : 0;
+  createPopup(msg.url, x, y);
+}
 
 function createPopup(url, x, y) {
     // Limit to max popups: do not open new ones when limit reached


### PR DESCRIPTION
### Motivation
- Enforce a single top-level owner for popup lifecycle so frame contexts only detect interactions and request previews rather than creating or managing popups.
- Remove ambiguous/dual message paths that allowed non-top frames or relays to trigger local popup creation, while preserving existing product behavior.

### Description
- Added a single explicit request path by introducing `requestPreviewOpen` messages and a top-level handler `handlePreviewOpenRequest` in `content.js` so all preview-open requests funnel to the top-level popup manager.
- Replaced direct frame/local popup creation on hover with a call to `requestPreviewOpen(url, x, y, 'hover')` so frames always send a request rather than creating popups themselves. 
- Normalized background relay logic in `background.js` so `openKeyPreview`, legacy `showPreview`, and frame-originated requests are forwarded as `requestPreviewOpen` to the tab, while keeping `lastHovers` for key-trigger behavior as a thin relay.
- Kept `showPreview` as a compatibility alias that now funnels into the single `requestPreviewOpen` path, and left popup creation/limits/dedupe/positioning entirely in the existing top-level popup manager code in `content.js`.
- Files changed: `content.js`, `background.js` (no other subsystems or settings/UI behavior changed).

### Testing
- Ran static syntax checks with `node --check content.js && node --check background.js && node --check iframe-handler.js` and they completed successfully.
- Verified the content runtime path now sends `requestPreviewOpen` on hover and key triggers by inspecting the updated message handling in `content.js` and `background.js`.
- No automated browser integration tests were available in this environment, so interactive QA listed in the repo acceptance criteria should be run manually (main-page preview open, nested-preview sibling open, iframe click navigation, popup limits, bringToFront/reload/close, settings regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c947042a60832f9c3fb7cf4908ac9f)