### PR TITLE
Simplify background to browser-level icon ownership

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,5 @@
-// Background service worker for the extension (currently empty) 
-
-// background.js
-// Icons for ON/OFF
+// Background service worker responsibilities are intentionally browser-level only:
+// - keep extension action icon in sync with enabled state.
 const ICON_ON = {
   '16': 'icons/icon-on.png',
   '32': 'icons/icon-on.png',
@@ -30,53 +28,3 @@ chrome.storage.onChanged.addListener((changes, area) => {
     refreshIcon();
   }
 });
-
-// Store last hovered link per tab for key-trigger previews
-let lastHovers = {};
-
-// Handle messages for hover update, key-trigger open, and relay showPreview
-chrome.runtime.onMessage.addListener((msg, sender) => {
-  if (sender.tab && sender.tab.id >= 0) {
-    if (msg.action === 'updateHover') {
-      lastHovers[sender.tab.id] = { url: msg.url, x: msg.x, y: msg.y, rect: msg.rect || null };
-      return;
-    }
-    if (msg.action === 'clearHover') {
-      delete lastHovers[sender.tab.id];
-      return;
-    }
-    if (msg.action === 'openKeyPreview') {
-      const data = lastHovers[sender.tab.id];
-      if (data && data.url) {
-        chrome.tabs.sendMessage(sender.tab.id, { action: 'requestPreviewOpen', url: data.url, x: data.x, y: data.y, rect: data.rect || null, trigger: 'key' });
-      }
-      return;
-    }
-    if (msg.action === 'bringToFront') {
-      chrome.tabs.sendMessage(sender.tab.id, {
-        action: 'bringToFront',
-        popupId: msg.popupId || null,
-        url: msg.url
-      });
-      return;
-    }
-    if (msg.action === 'requestPreviewOpen' || msg.action === 'showPreview') {
-      chrome.tabs.sendMessage(sender.tab.id, {
-        action: 'requestPreviewOpen',
-        url: msg.url,
-        x: msg.x,
-        y: msg.y,
-        rect: msg.rect || null,
-        trigger: msg.trigger || null
-      });
-      return;
-    }
-    if (msg.action === 'updatePopupUrl') {
-      chrome.tabs.sendMessage(sender.tab.id, {
-        action: 'updatePopupUrl',
-        popupId: msg.popupId || null,
-        url: msg.url
-      });
-    }
-  }
-}); 

--- a/content.js
+++ b/content.js
@@ -64,6 +64,10 @@ const hoverInteraction = {
   timerPending: false,
   keyEligible: false
 };
+const sharedHoverCandidate = {
+  url: null,
+  rect: null
+};
 
 function clearHoverTimer() {
   if (hoverInteraction.timerId) {
@@ -83,7 +87,8 @@ function resetHoverInteraction() {
 
 function dispatchHoverClear() {
   if (window.self === window.top) {
-    chrome.runtime.sendMessage({ action: 'clearHover' });
+    sharedHoverCandidate.url = null;
+    sharedHoverCandidate.rect = null;
     return;
   }
   window.parent.postMessage(
@@ -99,7 +104,7 @@ function dispatchHoverClear() {
 
 function dispatchKeyPreviewOpen() {
   if (window.self === window.top) {
-    chrome.runtime.sendMessage({ action: 'openKeyPreview' });
+    openKeyPreviewFromSharedHover();
     return;
   }
   window.parent.postMessage(
@@ -133,7 +138,12 @@ function onContentPointerOver(e) {
   hoverInteraction.activeUrl = link.href;
   hoverInteraction.activeRect = localRect;
   hoverInteraction.keyEligible = interactionType === 'hoverWithKey';
-  dispatchPreviewRequest('updateHover', link.href, localRect, null);
+  if (window.self === window.top) {
+    sharedHoverCandidate.url = link.href;
+    sharedHoverCandidate.rect = localRect;
+  } else {
+    dispatchPreviewRequest('updateHover', link.href, localRect, null);
+  }
 
   if (interactionType === 'hover') {
     const enteredLink = link;
@@ -188,11 +198,33 @@ function requestPreviewOpen(url, rectPayload, trigger) {
   dispatchPreviewRequest('requestPreviewOpen', url, rectPayload, trigger || null);
 }
 
+function openKeyPreviewFromSharedHover() {
+  if (!enabled) return;
+  if (!sharedHoverCandidate.url || !isRectPayload(sharedHoverCandidate.rect)) return;
+  const { x, y } = rectPayloadToAnchor(sharedHoverCandidate.rect);
+  handlePreviewOpenRequest({
+    action: 'requestPreviewOpen',
+    url: sharedHoverCandidate.url,
+    x,
+    y,
+    rect: sharedHoverCandidate.rect,
+    trigger: 'key'
+  });
+}
+
 function dispatchPreviewRequest(action, url, rectPayload, trigger) {
   if (!isRectPayload(rectPayload)) return;
   if (window.self === window.top) {
-    const { x, y } = rectPayloadToAnchor(rectPayload);
-    chrome.runtime.sendMessage({ action, url, x, y, rect: rectPayload, trigger });
+    if (action === 'updateHover') {
+      sharedHoverCandidate.url = url;
+      sharedHoverCandidate.rect = rectPayload;
+      return;
+    }
+    if (action === 'requestPreviewOpen' || action === 'showPreview') {
+      const { x, y } = rectPayloadToAnchor(rectPayload);
+      handlePreviewOpenRequest({ action: 'requestPreviewOpen', url, x, y, rect: rectPayload, trigger });
+      return;
+    }
     return;
   }
   window.parent.postMessage(
@@ -242,7 +274,7 @@ function onCoordinateHopMessage(event) {
   if (!isDirectChildWindow(event.source)) return;
   if (data.action === 'triggerKeyPreviewOpen') {
     if (window.self === window.top) {
-      chrome.runtime.sendMessage({ action: 'openKeyPreview' });
+      openKeyPreviewFromSharedHover();
       return;
     }
     window.parent.postMessage(data, '*');
@@ -250,7 +282,8 @@ function onCoordinateHopMessage(event) {
   }
   if (data.action === 'clearHover') {
     if (window.self === window.top) {
-      chrome.runtime.sendMessage({ action: 'clearHover' });
+      sharedHoverCandidate.url = null;
+      sharedHoverCandidate.rect = null;
       return;
     }
     window.parent.postMessage(data, '*');
@@ -266,14 +299,22 @@ function onCoordinateHopMessage(event) {
   }
 
   if (window.self === window.top) {
-    const { x, y } = rectPayloadToAnchor(rect);
-    chrome.runtime.sendMessage({
-      action: data.action,
-      url: data.url,
-      x,
-      y,
-      trigger: data.trigger || null
-    });
+    if (data.action === 'updateHover') {
+      sharedHoverCandidate.url = data.url;
+      sharedHoverCandidate.rect = rect;
+      return;
+    }
+    if (data.action === 'requestPreviewOpen') {
+      const { x, y } = rectPayloadToAnchor(rect);
+      handlePreviewOpenRequest({
+        action: 'requestPreviewOpen',
+        url: data.url,
+        x,
+        y,
+        rect,
+        trigger: data.trigger || null
+      });
+    }
     return;
   }
 
@@ -329,6 +370,22 @@ function handleRuntimeMessage(msg) {
   }
 }
 
+function onPopupRuntimeMessage(event) {
+  if (!enabled || window.self !== window.top) return;
+  const data = event && event.data;
+  if (!data || typeof data !== 'object') return;
+  if (data.source !== 'link-preview-extension' || data.type !== 'popup-runtime-bridge' || data.version !== 1) return;
+  if (!isDirectChildWindow(event.source)) return;
+
+  if (data.action === 'bringToFront') {
+    bringToFront(data.popupId || null, data.url);
+    return;
+  }
+  if (data.action === 'updatePopupUrl') {
+    syncPopupCurrentUrl(data.popupId || null, data.url);
+  }
+}
+
 function attachListeners() {
   if (listenersAttached) return;
   document.addEventListener('pointerover', onContentPointerOver);
@@ -336,6 +393,7 @@ function attachListeners() {
   document.addEventListener('keydown', onContentKeyDown);
   chrome.runtime.onMessage.addListener(handleRuntimeMessage);
   window.addEventListener('message', onCoordinateHopMessage);
+  window.addEventListener('message', onPopupRuntimeMessage);
   listenersAttached = true;
 }
 
@@ -346,6 +404,7 @@ function detachListeners() {
   document.removeEventListener('keydown', onContentKeyDown);
   chrome.runtime.onMessage.removeListener(handleRuntimeMessage);
   window.removeEventListener('message', onCoordinateHopMessage);
+  window.removeEventListener('message', onPopupRuntimeMessage);
   dispatchHoverClear();
   resetHoverInteraction();
   listenersAttached = false;

--- a/iframe-handler.js
+++ b/iframe-handler.js
@@ -16,11 +16,17 @@ if (window.self !== window.top) {
       ? window.frameElement.dataset.popupId
       : null;
     if (!popupId) return;
-    chrome.runtime.sendMessage({
-      action: 'updatePopupUrl',
-      popupId,
-      url: window.location.href
-    });
+    window.parent.postMessage(
+      {
+        source: 'link-preview-extension',
+        type: 'popup-runtime-bridge',
+        version: 1,
+        action: 'updatePopupUrl',
+        popupId,
+        url: window.location.href
+      },
+      '*'
+    );
   }
 
   if (document.readyState === 'complete') {
@@ -42,6 +48,16 @@ if (window.self !== window.top) {
     const popupId = window.frameElement && window.frameElement.dataset
       ? window.frameElement.dataset.popupId
       : null;
-    chrome.runtime.sendMessage({ action: 'bringToFront', popupId, url: window.location.href });
+    window.parent.postMessage(
+      {
+        source: 'link-preview-extension',
+        type: 'popup-runtime-bridge',
+        version: 1,
+        action: 'bringToFront',
+        popupId,
+        url: window.location.href
+      },
+      '*'
+    );
   });
 }


### PR DESCRIPTION
### Motivation
- Reduce background responsibilities to only what truly requires browser-level ownership (extension action/icon and startup hooks). 
- Remove background as a hidden owner of page-local preview interaction state so top-level content runtime becomes the source of truth for per-page behavior. 
- Preserve existing UX, popup ownership, frame bridge model, and settings semantics while keeping the diff minimal and reviewable. 

### Description
- Trimmed `background.js` to browser-level duties only by keeping icon sync logic tied to `chrome.storage.local.enabled` and removing per-tab hover state and message-relay logic. 
- Moved page-local hover/key-preview ownership into the top-level content runtime by adding a `sharedHoverCandidate` and `openKeyPreviewFromSharedHover` in `content.js`, and by handling `updateHover` / `requestPreviewOpen` locally when running in the top frame. 
- Reworked the dispatch flow so top-level frames directly open previews (`handlePreviewOpenRequest`) instead of routing through the background, while preserving cross-frame coordinate propagation (`preview-coordinate-hop`). 
- Replaced iframe -> background runtime relays for popup events with parent `postMessage` bridge messages (`popup-runtime-bridge`) in `iframe-handler.js` and added a `onPopupRuntimeMessage` handler in `content.js` to accept those events. 
- Kept `chrome.runtime.onMessage` handlers in `content.js` for legacy compatibility but no longer use background as the page-local source of truth. 
- Files changed: `background.js`, `content.js`, `iframe-handler.js`. 

### Testing
- Ran syntax checks which succeeded: `node --check background.js`, `node --check content.js`, and `node --check iframe-handler.js`. 
- No headless browser QA was performed in this environment, so manual extension QA is recommended for enable/disable toggling, multi-tab isolation, frame-originated preview flows, and popup lifecycle verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97e699058832f9118175d4e808c0b)